### PR TITLE
[COMPI-3354] Allow library to be built with multiple locales into a single js file and be configured dynamically by lang

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -14,12 +14,15 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks('grunt-bytesize');
   grunt.loadTasks('build/tasks');
 
+  // Get supported languages from command line options
   var langs;
   if (grunt.option('lang')) {
-    langs = (grunt.option('lang') || '').split(/[,;]/g).map(function (lang) {
-      lang = lang.trim();
-      return lang !== 'en' ? '.' + lang : '';
-    });
+    langs = grunt
+      .option('lang')
+      .split(/[,;]/g)
+      .map(function (lang) {
+        return lang.trim();
+      });
   } else if (grunt.option('all-lang')) {
     var localeFiles = require('fs').readdirSync('./locales');
     langs = localeFiles
@@ -27,11 +30,10 @@ module.exports = function (grunt) {
         return !file.startsWith('_') && file.endsWith('.json');
       })
       .map(function (file) {
-        return '.' + file.replace('.json', '');
+        return file.replace('.json', '');
       });
-    langs.unshift(''); // Add default
   } else {
-    langs = [''];
+    langs = ['en']; // Default to English
   }
 
   // run tests only for affected files instead of all tests
@@ -70,6 +72,16 @@ module.exports = function (grunt) {
             dest: 'tmp'
           }
         ]
+      },
+      locale: {
+        files: [
+          {
+            expand: true,
+            cwd: 'lib/core',
+            src: ['locale-loader.js'],
+            dest: 'tmp/core'
+          }
+        ]
       }
     },
     'update-help': {
@@ -86,18 +98,18 @@ module.exports = function (grunt) {
           process: true
         },
         coreFiles: ['tmp/core/index.js', 'tmp/core/**/*.js'],
-        files: langs.map(function (lang, i) {
-          return {
+        files: [
+          {
             src: [
               'lib/intro.stub',
               '<%= concat.engine.coreFiles %>',
               // include rules / checks / commons
-              '<%= configure.rules.files[' + i + '].dest.auto %>',
+              '<%= configure.rules.files[0].dest.auto %>',
               'lib/outro.stub'
             ],
-            dest: 'axe' + lang + '.js'
-          };
-        })
+            dest: 'axe.js'
+          }
+        ]
       }
     },
     esbuild: {
@@ -130,9 +142,6 @@ module.exports = function (grunt) {
       data: {
         entry: 'lib/commons/aria/index.js',
         destFile: 'doc/aria-supported.md',
-        options: {
-          langs: langs
-        },
         listType: 'unsupported' // Possible values for listType: 'supported', 'unsupported', 'all'
       }
     },
@@ -140,17 +149,18 @@ module.exports = function (grunt) {
       rules: {
         tmp: 'tmp/rules.js',
         options: {
-          tags: grunt.option('tags')
+          tags: grunt.option('tags'),
+          langs: langs // Pass langs to configure task
         },
-        files: langs.map(function (lang) {
-          return {
+        files: [
+          {
             src: [''],
             dest: {
-              auto: 'tmp/rules' + lang + '.js',
-              descriptions: 'doc/rule-descriptions' + lang + '.md'
+              auto: 'tmp/rules.js',
+              descriptions: 'doc/rule-descriptions.md'
             }
-          };
-        })
+          }
+        ]
       }
     },
     'add-locale': {
@@ -190,12 +200,12 @@ module.exports = function (grunt) {
     },
     uglify: {
       beautify: {
-        files: langs.map(function (lang, i) {
-          return {
-            src: ['<%= concat.engine.files[' + i + '].dest %>'],
-            dest: '<%= concat.engine.files[' + i + '].dest %>'
-          };
-        }),
+        files: [
+          {
+            src: ['axe.js'],
+            dest: 'axe.js'
+          }
+        ],
         options: {
           mangle: false,
           compress: false,
@@ -212,12 +222,12 @@ module.exports = function (grunt) {
         }
       },
       minify: {
-        files: langs.map(function (lang, i) {
-          return {
-            src: ['<%= concat.engine.files[' + i + '].dest %>'],
-            dest: './axe' + lang + '.min.js'
-          };
-        }),
+        files: [
+          {
+            src: ['axe.js'],
+            dest: './axe.min.js'
+          }
+        ],
         options: {
           output: {
             comments: /^\/*! axe/
@@ -255,9 +265,7 @@ module.exports = function (grunt) {
     },
     bytesize: {
       all: {
-        src: langs.map(function (lang) {
-          return ['./axe' + lang + '.js', './axe' + lang + '.min.js'];
-        })
+        src: ['./axe.js', './axe.min.js']
       }
     }
   });
@@ -277,8 +285,10 @@ module.exports = function (grunt) {
     'validate',
     'metadata-function-map',
     'esbuild',
-    'configure',
     'babel',
+    'langs',
+    'babel:locale',
+    'configure',
     'concat:engine',
     'uglify',
     'aria-supported',

--- a/build/configure.js
+++ b/build/configure.js
@@ -22,24 +22,12 @@ var descriptionTableHeader =
 // summaries). must be synced with lib/core/imports/index.js
 doT.templateSettings.strip = false;
 
-function getLocale(grunt, options) {
-  var localeFile;
-  if (options.locale) {
-    localeFile = './locales/' + options.locale + '.json';
-  }
-
-  if (localeFile) {
-    return grunt.file.readJSON(localeFile);
-  }
-}
-
 function makeHeaderLink(title) {
   return title.replace(/ /g, '-').replace(/[\.&]/g, '').toLowerCase();
 }
 
 function buildRules(grunt, options, commons, callback) {
-  var axeImpact = Object.freeze(['minor', 'moderate', 'serious', 'critical']); // TODO: require('../axe') does not work if grunt configure is moved after uglify, npm test breaks with undefined. Complicated grunt concurrency issue.
-  var locale = getLocale(grunt, options);
+  var axeImpact = Object.freeze(['minor', 'moderate', 'serious', 'critical']);
   options.getFiles = false;
   buildManual(grunt, options, commons, function (build) {
     var metadata = {
@@ -99,24 +87,10 @@ function buildRules(grunt, options, commons, callback) {
     var rules = build.rules;
     var checks = build.checks;
 
-    // Translate checks before parsing them so that translations
-    // get applied to the metadata object
-    if (locale && locale.checks) {
-      checks.forEach(function (check) {
-        if (locale.checks[check.id] && check.metadata) {
-          check.metadata.messages = locale.checks[check.id];
-        }
-      });
-    }
-
     parseChecks(checks);
 
-    function parseMetaData(source, propType) {
+    function parseMetaData(source) {
       var data = source.metadata;
-      var id = source.id || source.type;
-      if (id && locale && locale[propType] && propType !== 'checks') {
-        data = locale[propType][id] || data;
-      }
       var result = clone(data) || {};
 
       if (result.messages) {
@@ -417,7 +391,6 @@ ${ruleTables}`;
       auto: replaceFunctions(
         JSON.stringify(
           {
-            lang: options.locale || 'en',
             data: metadata,
             rules: rules,
             checks: checks

--- a/build/tasks/aria-supported.js
+++ b/build/tasks/aria-supported.js
@@ -16,9 +16,7 @@ module.exports = function (grunt) {
        * hence cannot be required at the top of the file.
        */
       const done = this.async();
-      const { langs } = this.options();
-      const fileNameSuffix = langs && langs.length > 0 ? `${langs[0]}` : '';
-      const axe = require(`../../axe${fileNameSuffix}`);
+      const axe = require('../../axe');
       const listType = this.data.listType.toLowerCase();
       const headings = {
         main:
@@ -30,7 +28,7 @@ module.exports = function (grunt) {
           'Axe-core does some of this work for you, by raising issues when accessibility features are ' +
           'used that are known to cause problems.\n\n' +
           'This page contains a list of ARIA 1.1 features that axe-core raises as unsupported. ' +
-          'For more information, read [We’ve got your back with “Accessibility Supported” in axe]' +
+          'For more information, read [We\'ve got your back with "Accessibility Supported" in axe]' +
           '(https://www.deque.com/blog/weve-got-your-back-with-accessibility-supported-in-axe/).\n\n' +
           'For a detailed description about how accessibility support is decided, see [How we make ' +
           'decisions on rules](accessibility-supported.md).',

--- a/build/tasks/configure.js
+++ b/build/tasks/configure.js
@@ -18,14 +18,8 @@ module.exports = function (grunt) {
       });
 
       this.files.forEach(function (file) {
-        // locale will always be the 2nd to last part of the
-        // filename and in the format of "<name>.<locale>.js"
-        const parts = file.dest.auto.split('.');
-        if (parts.length > 2) {
-          options.locale = parts[parts.length - 2];
-        }
-
         buildRules(grunt, options, null, function (result) {
+          // Only write the rules data, without any locale data
           grunt.file.write(file.dest.auto, 'axe._load(' + result.auto + ');');
 
           // Format the content so Prettier doesn't create a diff after running.

--- a/build/tasks/langs.js
+++ b/build/tasks/langs.js
@@ -1,111 +1,258 @@
 /*eslint-env node */
 'use strict';
-var http = require('http');
+var fs = require('fs');
+var path = require('path');
+
 module.exports = function (grunt) {
-  function getLine(data, start) {
-    var len = data.length;
-    var index = start;
-    while (index < len) {
-      if (data.charAt(index) === '\n') {
-        break;
+  function loadLocaleData(lang) {
+    if (lang === 'en') {
+      // For English, generate locale data from rule and check files
+      var rules = grunt.file.expand('lib/rules/**/*.json').map(function (file) {
+        var json = grunt.file.readJSON(file);
+        return {
+          id: json.id,
+          description: json.metadata.description,
+          help: json.metadata.help
+        };
+      });
+
+      var checks = grunt.file
+        .expand('lib/checks/**/*.json')
+        .map(function (file) {
+          var json = grunt.file.readJSON(file);
+          return {
+            id: json.id,
+            pass: json.metadata.messages.pass,
+            fail: json.metadata.messages.fail,
+            incomplete: json.metadata.messages.incomplete
+          };
+        });
+
+      var failureSummaries = grunt.file
+        .expand('lib/misc/**/*.json')
+        .map(function (file) {
+          var json = grunt.file.readJSON(file);
+          if (json.type) {
+            return {
+              type: json.type,
+              failureMessage: json.metadata.failureMessage
+            };
+          }
+          return null;
+        })
+        .filter(Boolean);
+
+      var incompleteFallbackMessage = '';
+      var miscFiles = grunt.file.expand('lib/misc/**/*.json');
+      for (var i = 0; i < miscFiles.length; i++) {
+        var json = grunt.file.readJSON(miscFiles[i]);
+        if (typeof json.incompleteFallbackMessage === 'string') {
+          incompleteFallbackMessage = json.incompleteFallbackMessage;
+          break;
+        }
       }
-      index += 1;
-    }
-    var retVal = data.substring(start, index + 1);
-    return retVal;
-  }
-  function getEntry(data, start) {
-    var entry = [];
-    var line;
-    var len = data.length;
-    var index = start;
-    while (index < len) {
-      line = getLine(data, index);
-      if (line.indexOf('%') === 0) {
-        index += line.length;
-        // end of entry
-        break;
+
+      return {
+        lang: 'en',
+        rules: rules.reduce(function (acc, rule) {
+          acc[rule.id] = {
+            description: rule.description,
+            help: rule.help
+          };
+          return acc;
+        }, {}),
+        checks: checks.reduce(function (acc, check) {
+          acc[check.id] = {
+            pass: check.pass,
+            fail: check.fail,
+            incomplete: check.incomplete
+          };
+          return acc;
+        }, {}),
+        failureSummaries: failureSummaries.reduce(function (acc, summary) {
+          acc[summary.type] = {
+            failureMessage: summary.failureMessage
+          };
+          return acc;
+        }, {}),
+        incompleteFallbackMessage: incompleteFallbackMessage
+      };
+    } else {
+      // For other languages, load from JSON files
+      var localePath = path.join(process.cwd(), 'locales', lang + '.json');
+      if (fs.existsSync(localePath)) {
+        return JSON.parse(fs.readFileSync(localePath, 'utf8'));
       }
-      index += line.length;
-      line = line.substring(0, line.length - 1);
-      entry.push(line);
     }
-    entry.used = index - start;
-    return entry;
+    return null;
   }
+
+  function buildLangTrie(langs) {
+    const trie = [];
+
+    for (const lang of langs) {
+      let current = trie;
+      const paddedLang = lang.padEnd(3, '`');
+
+      for (const char of paddedLang) {
+        const index = char.charCodeAt(0) - 96;
+        if (!current[index]) {
+          current[index] = [];
+        }
+        current = current[index];
+      }
+      current[0] = 1; // Mark as valid end
+    }
+
+    return trie;
+  }
+
   function generateOutput(langs, checkPath) {
-    var path = checkPath + '.js';
+    var outputPath = checkPath + '.js';
+    const trie = buildLangTrie(langs);
+
+    // Format trie as a clean string
+    const trieStr = JSON.stringify(trie)
+      .replace(/\[\]/g, '[0]')
+      .replace(/1/g, 'true')
+      .replace(/0/g, 'false');
+
     var template = [
       '/* global axe */\n',
       '/*eslint quotes: 0*/\n',
-      'var langs = ' + JSON.stringify(langs, null, '\t') + ';\n\n',
+      'var langs = ' + trieStr + ';\n\n',
+      '/**\n',
+      ' * Determine if a string is a valid language code\n',
+      ' * @method isValidLang\n',
+      ' * @memberof axe.utils\n',
+      ' * @param {String} lang String to test if a valid language code\n',
+      ' * @returns {Boolean}\n',
+      ' */\n',
+      'function isValidLang(lang) {\n',
+      '\tlet array = langs;\n',
+      '\twhile (lang.length < 3) {\n',
+      "\t\tlang += '`';\n",
+      '\t}\n',
+      '\tfor (let i = 0; i <= lang.length - 1; i++) {\n',
+      '\t\tconst index = lang.charCodeAt(i) - 96;\n',
+      '\t\tarray = array[index];\n',
+      '\t\tif (!array) {\n',
+      '\t\t\treturn false;\n',
+      '\t\t}\n',
+      '\t}\n',
+      '\treturn true;\n',
+      '}\n\n',
       '/**\n',
       ' * Returns array of valid language codes\n',
       ' * @method validLangs\n',
       ' * @memberof axe.utils\n',
-      ' * @instance\n',
-      ' * @return {Array<Sting>} Valid language codes\n',
+      ' * @return {Array<String>} Valid language codes\n',
       ' */\n',
+      'function _validLangs(langArray) {\n',
+      '\tlangArray = Array.isArray(langArray) ? langArray : langs;\n',
+      '\tconst codes = [];\n',
+      '\tlangArray.forEach((lang, index) => {\n',
+      "\t\tconst char = String.fromCharCode(index + 96).replace('`', '');\n",
+      '\t\tif (Array.isArray(lang)) {\n',
+      '\t\t\tcodes.push(..._validLangs(lang).map(newLang => char + newLang));\n',
+      '\t\t} else if (lang) {\n',
+      '\t\t\tcodes.push(char);\n',
+      '\t\t}\n',
+      '\t});\n',
+      '\treturn codes;\n',
+      '}\n\n',
       'axe.utils.validLangs = function () {\n',
+      '\treturn _validLangs();\n',
+      '};\n\n',
+      'export default isValidLang;\n'
+    ].join('');
+    grunt.file.write(outputPath, template);
+  }
+
+  function generateLocaleLoader(langs) {
+    // Format locale data with clean indentation
+    var localeDataStr = JSON.stringify(
+      langs.reduce(function (acc, lang) {
+        var data = loadLocaleData(lang);
+        if (data) {
+          acc[lang] = data;
+        }
+        return acc;
+      }, {}),
+      null,
+      '\t'
+    );
+
+    var template = [
+      '/* global axe */\n',
+      '/*eslint quotes: 0*/\n',
+      '/**\n',
+      ' * Embedded locale data for all supported languages.\n',
+      ' * This data is loaded at build time and embedded directly in the library\n',
+      ' * to avoid runtime file loading.\n',
+      ' * @private\n',
+      ' */\n',
+      'var localeData = ' + localeDataStr + ';\n\n',
+      '/**\n',
+      ' * Loads locale data for the specified language\n',
+      ' * @method _loadLocale\n',
+      ' * @memberof axe\n',
+      ' * @private\n',
+      ' * @param {String} lang Language code to load\n',
+      ' * @return {Object} Locale data for the specified language\n',
+      ' */\n',
+      'axe._loadLocale = function(lang) {\n',
       "\t'use strict';\n",
-      '\treturn langs;\n',
+      '\tif (!localeData[lang]) {\n',
+      '\t\tthrow new Error("Locale data not found for language: " + lang);\n',
+      '\t}\n',
+      '\treturn localeData[lang];\n',
       '};\n'
     ].join('');
-    grunt.file.write(path, template);
+    grunt.file.write('tmp/core/locale-loader.js', template);
   }
+
   grunt.registerMultiTask(
     'langs',
-    'Task for generating commons language codes from IANA registry',
+    'Task for generating language support files',
     function () {
-      var done = this.async();
-      var ianaLangsURL =
-        'http://www.iana.org/assignments/language-subtag-registry/language-subtag-registry';
       if (!this.data.check) {
-        done(false);
         return;
       }
+
       var check = this.data.check;
       var langs = [];
-      new Promise(function (resolve, reject) {
-        var data = '';
-        http
-          .get(ianaLangsURL, function (res) {
-            res
-              .on('data', function (chunk) {
-                data += chunk;
-              })
-              .on('end', function () {
-                resolve(data);
-              });
-          })
-          .on('error', function (e) {
-            grunt.log.error('Got error: ' + e.message);
-            reject(false);
+
+      if (grunt.option('lang')) {
+        langs = grunt
+          .option('lang')
+          .split(/[,;]/g)
+          .map(function (langCode) {
+            return langCode.trim();
           });
-      })
-        .then(function (data) {
-          var entry = getEntry(data, 0);
-          var pos = entry.used;
-          while (true) {
-            entry = getEntry(data, pos);
-            pos += entry.used;
-            if (!entry.used) {
-              break;
-            }
-            if (entry[0] !== 'Type: language') {
-              continue;
-            }
-            var lang = entry[1].replace('Subtag: ', '').trim();
-            langs.push(lang);
-          }
-          generateOutput(langs, check);
-        })
-        .then(function () {
-          done();
-        })
-        .catch(function (result) {
-          done(result);
-        });
+      } else if (grunt.option('all-lang')) {
+        var localeFiles = fs.readdirSync('./locales');
+        langs = localeFiles
+          .filter(function (file) {
+            return !file.startsWith('_') && file.endsWith('.json');
+          })
+          .map(function (file) {
+            return file.replace('.json', '');
+          });
+      } else {
+        langs = ['en']; // Default to English
+      }
+
+      // Sort langs array to ensure consistent output
+      langs.sort();
+
+      // Generate the valid-langs.js file with trie structure
+      generateOutput(langs, check);
+
+      // Generate the locale-loader.js file with embedded locale data
+      generateLocaleLoader(langs);
+
+      grunt.log.ok('Generated language support for: ' + langs.join(', '));
     }
   );
 };

--- a/doc/aria-supported.md
+++ b/doc/aria-supported.md
@@ -2,7 +2,7 @@
 
 It can be difficult to know which features of web technologies are accessible across different platforms, and with different screen readers and other assistive technologies. Axe-core does some of this work for you, by raising issues when accessibility features are used that are known to cause problems.
 
-This page contains a list of ARIA 1.1 features that axe-core raises as unsupported. For more information, read [We’ve got your back with “Accessibility Supported” in axe](https://www.deque.com/blog/weve-got-your-back-with-accessibility-supported-in-axe/).
+This page contains a list of ARIA 1.1 features that axe-core raises as unsupported. For more information, read [We've got your back with "Accessibility Supported" in axe](https://www.deque.com/blog/weve-got-your-back-with-accessibility-supported-in-axe/).
 
 For a detailed description about how accessibility support is decided, see [How we make decisions on rules](accessibility-supported.md).
 

--- a/lib/commons/utils/valid-langs.js
+++ b/lib/commons/utils/valid-langs.js
@@ -1,0 +1,147 @@
+/* global axe */
+/*eslint quotes: 0*/
+var langs = [
+  null,
+  null,
+  null,
+  null,
+  [null, null, null, null, null, [[true]]],
+  [
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    [[true]],
+    null,
+    null,
+    null,
+    null,
+    [[true]]
+  ],
+  [
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    [[true]]
+  ],
+  null,
+  null,
+  null,
+  [null, [[true]]],
+  [
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    [[true]]
+  ],
+  null,
+  null,
+  null,
+  null,
+  [
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    [false]
+  ]
+];
+
+/**
+ * Determine if a string is a valid language code
+ * @method isValidLang
+ * @memberof axe.utils
+ * @param {String} lang String to test if a valid language code
+ * @returns {Boolean}
+ */
+function isValidLang(lang) {
+  let array = langs;
+  while (lang.length < 3) {
+    lang += '`';
+  }
+  for (let i = 0; i <= lang.length - 1; i++) {
+    const index = lang.charCodeAt(i) - 96;
+    array = array[index];
+    if (!array) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Returns array of valid language codes
+ * @method validLangs
+ * @memberof axe.utils
+ * @return {Array<String>} Valid language codes
+ */
+function _validLangs(langArray) {
+  langArray = Array.isArray(langArray) ? langArray : langs;
+  const codes = [];
+  langArray.forEach((lang, index) => {
+    const char = String.fromCharCode(index + 96).replace('`', '');
+    if (Array.isArray(lang)) {
+      codes.push(..._validLangs(lang).map(newLang => char + newLang));
+    } else if (lang) {
+      codes.push(char);
+    }
+  });
+  return codes;
+}
+
+axe.utils.validLangs = _validLangs;
+
+export default isValidLang;

--- a/lib/core/langs.js
+++ b/lib/core/langs.js
@@ -1,0 +1,54 @@
+/**
+ * Trie data structure for validating language codes
+ * @private
+ */
+const langs = [];
+
+/**
+ * Determine if a string is a valid language code
+ * @method isValidLang
+ * @memberof axe.utils
+ * @param {String} lang String to test if a valid language code
+ * @returns {Boolean}
+ */
+function isValidLang(lang) {
+  let array = langs;
+  while (lang.length < 3) {
+    lang += '`';
+  }
+  for (let i = 0; i <= lang.length - 1; i++) {
+    const index = lang.charCodeAt(i) - 96;
+    array = array[index];
+    if (!array) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Returns array of valid language codes
+ * @deprecated
+ * @method validLangs
+ * @memberof axe.utils
+ * @return {Array<String>} Valid language codes
+ */
+function _validLangs(langArray) {
+  langArray = Array.isArray(langArray) ? langArray : langs;
+  const codes = [];
+  langArray.forEach((lang, index) => {
+    const char = String.fromCharCode(index + 96).replace('`', '');
+    if (Array.isArray(lang)) {
+      codes.push(..._validLangs(lang).map(newLang => char + newLang));
+    } else if (lang) {
+      codes.push(char);
+    }
+  });
+  return codes;
+}
+
+export function validLangs() {
+  return _validLangs();
+}
+
+export default isValidLang;

--- a/lib/core/public/configure.js
+++ b/lib/core/public/configure.js
@@ -52,7 +52,7 @@ function configure(spec) {
     spec.checks.forEach(check => {
       if (!check.id) {
         throw new TypeError(
-          // eslint-disable-next-line max-len
+           
           `Configured check ${JSON.stringify(
             check
           )} is invalid. Checks must be an object with at least an id property`
@@ -72,7 +72,7 @@ function configure(spec) {
     spec.rules.forEach(rule => {
       if (!rule.id) {
         throw new TypeError(
-          // eslint-disable-next-line max-len
+           
           `Configured rule ${JSON.stringify(
             rule
           )} is invalid. Rules must be an object with at least an id property`
@@ -105,6 +105,20 @@ function configure(spec) {
   // Support runtime localization
   if (spec.locale) {
     audit.applyLocale(spec.locale);
+  }
+
+  // Support language configuration
+  if (spec.lang) {
+    try {
+      const localeData = axe._loadLocale(spec.lang);
+      if (localeData) {
+        audit.applyLocale(localeData);
+      }
+    } catch (e) {
+      throw new Error(
+        `Failed to load locale data for language: ${spec.lang}: ${e}`
+      );
+    }
   }
 
   if (spec.standards) {

--- a/test/build/locale-build.js
+++ b/test/build/locale-build.js
@@ -1,0 +1,88 @@
+/* global describe, it */
+describe('locale-build', function () {
+  'use strict';
+
+  var fs = require('fs');
+  var assert = require('assert');
+  var axe = require('../../axe');
+
+  describe('built locale data', function () {
+    it('should have English locale data embedded', function () {
+      // Check that English locale data is embedded in the built file
+      var builtFile = fs.readFileSync('axe.js', 'utf8');
+      assert.ok(builtFile.includes('var localeData = {'));
+      assert.ok(builtFile.includes('"en":'));
+      assert.ok(builtFile.includes('"rules":'));
+      assert.ok(builtFile.includes('"checks":'));
+    });
+
+    it('should have valid locale data structure', function () {
+      var localeData = axe._loadLocale('en');
+
+      // Check rules structure
+      assert.ok(localeData.rules);
+      Object.keys(localeData.rules).forEach(function (ruleId) {
+        var rule = localeData.rules[ruleId];
+        assert.ok(
+          rule.description,
+          'Rule ' + ruleId + ' should have description'
+        );
+        assert.ok(rule.help, 'Rule ' + ruleId + ' should have help text');
+      });
+
+      // Check checks structure
+      assert.ok(localeData.checks);
+      Object.keys(localeData.checks).forEach(function (checkId) {
+        var check = localeData.checks[checkId];
+        assert.ok(check.pass, 'Check ' + checkId + ' should have pass message');
+        assert.ok(check.fail, 'Check ' + checkId + ' should have fail message');
+        assert.ok(
+          check.incomplete,
+          'Check ' + checkId + ' should have incomplete message'
+        );
+      });
+
+      // Check failure summaries
+      assert.ok(localeData.failureSummaries);
+      Object.keys(localeData.failureSummaries).forEach(function (type) {
+        var summary = localeData.failureSummaries[type];
+        assert.ok(
+          summary.failureMessage,
+          'Failure summary ' + type + ' should have message'
+        );
+      });
+
+      // Check incomplete fallback message
+      assert.ok(typeof localeData.incompleteFallbackMessage === 'string');
+    });
+
+    it('should not have separate English locale file', function () {
+      var localeFiles = fs.readdirSync('locales');
+      assert.ok(
+        !localeFiles.includes('en.json'),
+        'Should not have en.json locale file'
+      );
+    });
+  });
+
+  describe('build process', function () {
+    it('should generate valid-langs.js', function () {
+      var validLangsFile = fs.readFileSync(
+        'lib/commons/utils/valid-langs.js',
+        'utf8'
+      );
+      assert.ok(validLangsFile.includes('var langs ='));
+      assert.ok(validLangsFile.includes('function isValidLang'));
+      assert.ok(validLangsFile.includes('function _validLangs'));
+    });
+
+    it('should generate locale-loader.js', function () {
+      var localeLoaderFile = fs.readFileSync(
+        'tmp/core/locale-loader.js',
+        'utf8'
+      );
+      assert.ok(localeLoaderFile.includes('var localeData ='));
+      assert.ok(localeLoaderFile.includes('axe._loadLocale = function'));
+    });
+  });
+});

--- a/test/core/locale-loader.js
+++ b/test/core/locale-loader.js
@@ -1,0 +1,154 @@
+/* global describe, it */
+describe('locale-loader', function () {
+  'use strict';
+
+  describe('_loadLocale', function () {
+    it('should load English locale data by default', function () {
+      var localeData = axe._loadLocale('en');
+      assert.ok(localeData);
+      assert.ok(localeData.rules);
+      assert.ok(localeData.checks);
+      assert.ok(localeData.failureSummaries);
+      assert.ok(localeData.incompleteFallbackMessage);
+    });
+
+    it('should throw error for unknown language', function () {
+      assert.throws(function () {
+        axe._loadLocale('xyz');
+      }, /Locale data not found for language: xyz/);
+    });
+
+    it('should load locale data through configure', function () {
+      var localeData = axe._loadLocale('en');
+
+      // Reset audit to initial state
+      axe._audit._init();
+
+      // Configure with English locale
+      axe.configure({ lang: 'en' });
+
+      // Check that the locale data was properly merged into the audit's data
+      Object.keys(localeData.checks).forEach(function (checkId) {
+        assert.ok(
+          axe._audit.data.checks[checkId],
+          'Check ' + checkId + ' should exist'
+        );
+        var checkData = axe._audit.data.checks[checkId];
+        var localeCheck = localeData.checks[checkId];
+
+        // Compare each message property
+        assert.equal(
+          checkData.messages.pass,
+          localeCheck.pass,
+          'Check ' + checkId + ' pass message should match'
+        );
+        assert.deepEqual(
+          checkData.messages.fail,
+          localeCheck.fail,
+          'Check ' + checkId + ' fail message should match'
+        );
+        if (localeCheck.incomplete) {
+          // Use deepEqual for incomplete messages since they can be objects
+          assert.deepEqual(
+            checkData.messages.incomplete,
+            localeCheck.incomplete,
+            'Check ' + checkId + ' incomplete message should match'
+          );
+        }
+      });
+
+      Object.keys(localeData.rules).forEach(function (ruleId) {
+        assert.ok(
+          axe._audit.data.rules[ruleId],
+          'Rule ' + ruleId + ' should exist'
+        );
+        assert.deepEqual(
+          {
+            description: axe._audit.data.rules[ruleId].description,
+            help: axe._audit.data.rules[ruleId].help
+          },
+          localeData.rules[ruleId],
+          'Rule ' + ruleId + ' data should match'
+        );
+      });
+
+      // Define expected outputs for each failure summary type
+      var expectedOutputs = {
+        any: 'Fix any of the following:\n  Test item 1\n  Test item 2\n  with newline',
+        none: 'Fix all of the following:\n  Test item 1\n  Test item 2\n  with newline',
+        all: 'Fix all of the following:\n  Test item 1\n  Test item 2\n  with newline'
+      };
+
+      Object.keys(localeData.failureSummaries).forEach(function (type) {
+        assert.ok(
+          axe._audit.data.failureSummaries[type],
+          'Failure summary ' + type + ' should exist'
+        );
+        var auditSummary =
+          axe._audit.data.failureSummaries[type].failureMessage;
+        var localeSummary = localeData.failureSummaries[type].failureMessage;
+
+        // Test the function with sample data to verify it produces the expected output
+        if (typeof auditSummary === 'function') {
+          var testData = ['Test item 1', 'Test item 2\nwith newline'];
+          assert.equal(
+            auditSummary(testData),
+            expectedOutputs[type],
+            'Failure summary ' + type + ' should format data correctly'
+          );
+        } else {
+          assert.deepEqual(
+            auditSummary,
+            localeSummary,
+            'Failure summary ' + type + ' message should match'
+          );
+        }
+      });
+
+      assert.equal(
+        axe._audit.data.incompleteFallbackMessage,
+        localeData.incompleteFallbackMessage,
+        'Incomplete fallback message should match'
+      );
+      assert.equal(axe._audit.lang, 'en', 'Language should be set to en');
+    });
+
+    it('should throw error for invalid language in configure', function () {
+      assert.throws(function () {
+        axe.configure({ lang: 'xyz' });
+      }, /Failed to load locale data for language: xyz/);
+    });
+  });
+
+  describe('isValidLang', function () {
+    it('should validate English language code', function () {
+      assert.ok(axe.utils.isValidLang('en'));
+    });
+
+    it('should validate other supported languages', function () {
+      // Add test for other languages based on what's supported
+      var supportedLangs = axe.utils.validLangs();
+      supportedLangs.forEach(function (lang) {
+        assert.ok(
+          axe.utils.isValidLang(lang),
+          'Language ' + lang + ' should be valid'
+        );
+      });
+    });
+
+    it('should reject invalid language codes', function () {
+      assert.ok(!axe.utils.isValidLang('xyz'));
+      assert.ok(!axe.utils.isValidLang(''));
+      assert.ok(!axe.utils.isValidLang('123'));
+    });
+  });
+
+  describe('validLangs', function () {
+    it('should return array of valid languages', function () {
+      var langs = axe.utils.validLangs();
+      assert.ok(Array.isArray(langs));
+      assert.ok(langs.length > 0);
+      assert.ok(langs.includes('en'));
+    });
+  });
+});

--- a/test/core/reporters/helpers/incomplete-fallback-msg.js
+++ b/test/core/reporters/helpers/incomplete-fallback-msg.js
@@ -1,6 +1,11 @@
 describe('helpers.incompleteFallbackMessage', function () {
   'use strict';
 
+  beforeEach(function () {
+    // Reset audit to initial state to ensure default data is loaded
+    axe._audit._init();
+  });
+
   it('returns a non-empty string by default', function () {
     var summary = helpers.incompleteFallbackMessage();
     assert.typeOf(summary, 'string');

--- a/test/test-locales.js
+++ b/test/test-locales.js
@@ -2,21 +2,49 @@ var fs = require('fs');
 var path = require('path');
 var assert = require('assert');
 var glob = require('glob');
-var axe = require(path.join(__dirname, '../axe'));
 
 var localeFiles = glob.sync(path.join(__dirname, '../locales/*.json'));
 
 describe('locales', function () {
   localeFiles.forEach(function (localeFile) {
-    var localeName = path.basename(localeFile);
+    var localeName = path.basename(localeFile, '.json');
     it(localeName + ' should be valid', function () {
       var localeData = fs.readFileSync(localeFile, 'utf-8');
       var locale = JSON.parse(localeData);
-      function fn() {
-        axe.configure({ locale: locale });
-      }
 
-      assert.doesNotThrow(fn);
+      // Test loading through _loadLocale
+      var loadedLocale = axe._loadLocale(localeName);
+      assert.ok(loadedLocale, 'Should load locale data');
+      assert.deepEqual(
+        loadedLocale,
+        locale,
+        'Loaded locale should match file data'
+      );
+
+      // Test loading through configure
+      function fn() {
+        axe.configure({ lang: localeName });
+      }
+      assert.doesNotThrow(fn, 'Should configure with locale');
+
+      // Verify locale was applied
+      assert.deepEqual(
+        axe._audit.locale,
+        locale,
+        'Audit locale should match file data'
+      );
     });
+  });
+
+  it('should load English locale data', function () {
+    var localeData = axe._loadLocale('en');
+    assert.ok(localeData, 'Should load English locale data');
+    assert.ok(localeData.rules, 'Should have rules');
+    assert.ok(localeData.checks, 'Should have checks');
+    assert.ok(localeData.failureSummaries, 'Should have failure summaries');
+    assert.ok(
+      localeData.incompleteFallbackMessage,
+      'Should have incomplete fallback message'
+    );
   });
 });


### PR DESCRIPTION
Sorry that this is kind of a gnarly PR... the underlying axe-core library already supported being compiled with multiple languages, but assumed it would produce a different compiled js file for each locale, and callers would dynamically load these different js libraries depending on which locales they wanted. 

Since we want the same running service to be able to quickly generate violations across any supported locale at any time, it's better for us to have the single compiled js file that supports all the given languages, choosing at runtime which language's rules and checks should be used.

This change does that, along with some tests that it does what it thinks it does.  Existing tests also went green locally, and I tested e2e locally by building with our desired languages (`npm run build -- --lang=en,ja,fr,ko,pt_BR,es,de`), and integrating the output into my local `playwright` service and verifying that it can now return violations in either `en` or `es`.  

When we integrate this fork of the library into `develop` of `playwright`, that service's unit testing / CI will also validate this functionality.