### PR TITLE
[COMPI-3354] Handle the lang configuration option more defensively, with fallbacks

### DIFF
--- a/build/tasks/langs.js
+++ b/build/tasks/langs.js
@@ -203,9 +203,7 @@ module.exports = function (grunt) {
       ' */\n',
       'axe._loadLocale = function(lang) {\n',
       "\t'use strict';\n",
-      '\tif (!localeData[lang]) {\n',
-      '\t\tthrow new Error("Locale data not found for language: " + lang);\n',
-      '\t}\n',
+
       '\treturn localeData[lang];\n',
       '};\n'
     ].join('');

--- a/lib/commons/utils/valid-langs.js
+++ b/lib/commons/utils/valid-langs.js
@@ -1,104 +1,6 @@
 /* global axe */
 /*eslint quotes: 0*/
-var langs = [
-  null,
-  null,
-  null,
-  null,
-  [null, null, null, null, null, [[true]]],
-  [
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    [[true]],
-    null,
-    null,
-    null,
-    null,
-    [[true]]
-  ],
-  [
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    [[true]]
-  ],
-  null,
-  null,
-  null,
-  [null, [[true]]],
-  [
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    [[true]]
-  ],
-  null,
-  null,
-  null,
-  null,
-  [
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    [false]
-  ]
-];
+var langs = [null,null,null,null,[null,null,null,null,null,[[true]]],[null,null,null,null,null,null,null,null,null,null,null,null,null,null,[[true]],null,null,null,null,[[true]]],[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,[[true]]],null,null,null,[null,[[true]]],[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,[[true]]],null,null,null,null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,[false]]];
 
 /**
  * Determine if a string is a valid language code
@@ -108,18 +10,18 @@ var langs = [
  * @returns {Boolean}
  */
 function isValidLang(lang) {
-  let array = langs;
-  while (lang.length < 3) {
-    lang += '`';
-  }
-  for (let i = 0; i <= lang.length - 1; i++) {
-    const index = lang.charCodeAt(i) - 96;
-    array = array[index];
-    if (!array) {
-      return false;
-    }
-  }
-  return true;
+	let array = langs;
+	while (lang.length < 3) {
+		lang += '`';
+	}
+	for (let i = 0; i <= lang.length - 1; i++) {
+		const index = lang.charCodeAt(i) - 96;
+		array = array[index];
+		if (!array) {
+			return false;
+		}
+	}
+	return true;
 }
 
 /**
@@ -129,19 +31,21 @@ function isValidLang(lang) {
  * @return {Array<String>} Valid language codes
  */
 function _validLangs(langArray) {
-  langArray = Array.isArray(langArray) ? langArray : langs;
-  const codes = [];
-  langArray.forEach((lang, index) => {
-    const char = String.fromCharCode(index + 96).replace('`', '');
-    if (Array.isArray(lang)) {
-      codes.push(..._validLangs(lang).map(newLang => char + newLang));
-    } else if (lang) {
-      codes.push(char);
-    }
-  });
-  return codes;
+	langArray = Array.isArray(langArray) ? langArray : langs;
+	const codes = [];
+	langArray.forEach((lang, index) => {
+		const char = String.fromCharCode(index + 96).replace('`', '');
+		if (Array.isArray(lang)) {
+			codes.push(..._validLangs(lang).map(newLang => char + newLang));
+		} else if (lang) {
+			codes.push(char);
+		}
+	});
+	return codes;
 }
 
-axe.utils.validLangs = _validLangs;
+axe.utils.validLangs = function () {
+	return _validLangs();
+};
 
 export default isValidLang;

--- a/lib/core/public/configure.js
+++ b/lib/core/public/configure.js
@@ -100,31 +100,39 @@ function configure(spec) {
     audit.tagExclude = spec.tagExclude;
   }
 
-  // Support runtime localization
+  // Support runtime localization (providing an entire locale object)
   if (spec.locale) {
     audit.applyLocale(spec.locale);
   }
 
-  // Support language configuration
+  // Support runtime localization (providing a locale or language code)
   if (spec.lang) {
-    try {
-      const localeData = axe._loadLocale(spec.lang);
-      if (localeData) {
-        audit.applyLocale(localeData);
-      }
-    } catch (e) {
-      // Fall back to English for unknown languages
+    // First try full language/locale pair (with underscores instead of dashes)
+    const normalizedLang = spec.lang
+      .replace(/-/g, '_')
+      .replace(/_([a-z]+)/g, (_, letters) => '_' + letters.toUpperCase());
+    let localeData = axe._loadLocale(normalizedLang);
+
+    if (!localeData) {
+      // If that fails, try just the base language (before any underscore)
+      const baseLang = normalizedLang.split('_')[0];
+      localeData = axe._loadLocale(baseLang);
+    }
+
+    if (!localeData) {
+      // If both attempts fail, fall back to English
       console.warn(
-        `Failed to load locale data for language: ${spec.lang}: ${e.message}, falling back to English`
+        `Failed to load locale data for language: ${spec.lang}, falling back to English`
       );
-      try {
-        const englishLocale = axe._loadLocale('en');
-        if (englishLocale) {
-          audit.applyLocale(englishLocale);
-        }
-      } catch (fallbackError) {
-        console.error('Failed to load English locale data:', fallbackError);
-      }
+      localeData = axe._loadLocale('en');
+    }
+
+    if (localeData) {
+      audit.applyLocale(localeData);
+    } else {
+      throw new Error(
+        `Failed to load locale data for language: ${spec.lang}, no locale data available`
+      );
     }
   }
 

--- a/lib/core/public/configure.js
+++ b/lib/core/public/configure.js
@@ -52,7 +52,6 @@ function configure(spec) {
     spec.checks.forEach(check => {
       if (!check.id) {
         throw new TypeError(
-           
           `Configured check ${JSON.stringify(
             check
           )} is invalid. Checks must be an object with at least an id property`
@@ -72,7 +71,6 @@ function configure(spec) {
     spec.rules.forEach(rule => {
       if (!rule.id) {
         throw new TypeError(
-           
           `Configured rule ${JSON.stringify(
             rule
           )} is invalid. Rules must be an object with at least an id property`
@@ -115,9 +113,18 @@ function configure(spec) {
         audit.applyLocale(localeData);
       }
     } catch (e) {
-      throw new Error(
-        `Failed to load locale data for language: ${spec.lang}: ${e}`
+      // Fall back to English for unknown languages
+      console.warn(
+        `Failed to load locale data for language: ${spec.lang}: ${e.message}, falling back to English`
       );
+      try {
+        const englishLocale = axe._loadLocale('en');
+        if (englishLocale) {
+          audit.applyLocale(englishLocale);
+        }
+      } catch (fallbackError) {
+        console.error('Failed to load English locale data:', fallbackError);
+      }
     }
   }
 

--- a/test/core/locale-loader.js
+++ b/test/core/locale-loader.js
@@ -113,10 +113,11 @@ describe('locale-loader', function () {
       assert.equal(axe._audit.lang, 'en', 'Language should be set to en');
     });
 
-    it('should throw error for invalid language in configure', function () {
-      assert.throws(function () {
-        axe.configure({ lang: 'xyz' });
-      }, /Failed to load locale data for language: xyz/);
+    it('should fall back to English for unknown language in configure', function () {
+      // Configure with unknown language
+      axe.configure({ lang: 'xyz' });
+      // Verify English locale was applied
+      assert.equal(axe._audit.lang, 'en');
     });
   });
 

--- a/test/core/locale-loader.js
+++ b/test/core/locale-loader.js
@@ -12,10 +12,8 @@ describe('locale-loader', function () {
       assert.ok(localeData.incompleteFallbackMessage);
     });
 
-    it('should throw error for unknown language', function () {
-      assert.throws(function () {
-        axe._loadLocale('xyz');
-      }, /Locale data not found for language: xyz/);
+    it('should return undefined for unknown language', function () {
+      assert.isUndefined(axe._loadLocale('xyz'));
     });
 
     it('should load locale data through configure', function () {

--- a/test/core/public/configure.js
+++ b/test/core/public/configure.js
@@ -1080,4 +1080,64 @@ describe('axe.configure', function () {
       });
     });
   });
+
+  describe('language fallback behavior', function () {
+    beforeEach(function () {
+      axe._load({});
+    });
+
+    it('should try full language code with underscores first', function () {
+      // Mock _loadLocale to return data for fr_FR
+      axe._loadLocale = function (lang) {
+        if (lang === 'pt_BR') {
+          return { lang: 'pt_BR', rules: {}, checks: {} };
+        }
+        return null;
+      };
+
+      axe.configure({ lang: 'pt-br' });
+      assert.equal(axe._audit.lang, 'pt_BR');
+    });
+
+    it('should fall back to base language if full code not found', function () {
+      // Mock _loadLocale to return data for fr but not fr_FR
+      axe._loadLocale = function (lang) {
+        if (lang === 'pt') {
+          return { lang: 'pt', rules: {}, checks: {} };
+        }
+        return null;
+      };
+
+      axe.configure({ lang: 'pt-br' });
+      assert.equal(axe._audit.lang, 'pt');
+    });
+
+    it('should fall back to English if neither full nor base language found', function () {
+      // Mock _loadLocale to return data only for en
+      axe._loadLocale = function (lang) {
+        if (lang === 'en') {
+          return { lang: 'en', rules: {}, checks: {} };
+        }
+        return null;
+      };
+
+      axe.configure({ lang: 'xyz-ABC' });
+      assert.equal(axe._audit.lang, 'en');
+    });
+
+    it('should throw error if no locale data is available', function () {
+      // Mock _loadLocale to return null for all languages
+      axe._loadLocale = function () {
+        return null;
+      };
+
+      assert.throws(
+        function () {
+          axe.configure({ lang: 'xyz-ABC' });
+        },
+        Error,
+        'Failed to load locale data for language: xyz-ABC, no locale data available'
+      );
+    });
+  });
 });


### PR DESCRIPTION
* Accept language/locale pairs like `en-us` (platform's format) or `en_US` (the internal format)
* Accept language/locale pair or just language (important because internally the data has only pt_BR actually including locale)
* When in doubt, fall back to english